### PR TITLE
Moved func to different struct, added test & doc

### DIFF
--- a/confirms_test.go
+++ b/confirms_test.go
@@ -216,3 +216,22 @@ func TestDeferredConfirmationsConfirmMultiple(t *testing.T) {
 		t.Fatal("expected to receive true for result, received false")
 	}
 }
+
+func TestDeferredConfirmationsClose(t *testing.T) {
+	dcs := newDeferredConfirmations()
+	var wg sync.WaitGroup
+	var result bool
+	dc1 := dcs.Add(1)
+	dc2 := dcs.Add(2)
+	dc3 := dcs.Add(3)
+	wg.Add(1)
+	go func() {
+		result = dc1.Wait() && dc2.Wait() && dc3.Wait()
+		wg.Done()
+	}()
+	dcs.Close()
+	wg.Wait()
+	if result {
+		t.Fatal("expected to receive false for nacked confirmations, received true")
+	}
+}

--- a/confirms_test.go
+++ b/confirms_test.go
@@ -226,12 +226,12 @@ func TestDeferredConfirmationsClose(t *testing.T) {
 	dc3 := dcs.Add(3)
 	wg.Add(1)
 	go func() {
-		result = dc1.Wait() && dc2.Wait() && dc3.Wait()
+		result = !dc1.Wait() && !dc2.Wait() && !dc3.Wait()
 		wg.Done()
 	}()
 	dcs.Close()
 	wg.Wait()
-	if result {
+	if !result {
 		t.Fatal("expected to receive false for nacked confirmations, received true")
 	}
 }


### PR DESCRIPTION
Made the code more consistent and reliable by moving the logic to a method of `*deferredConfirmations` which goes through *all* confirmations, no matter the tag. Added a test for this new method, and some documentation (that I personally wish I had earlier) for clarity.